### PR TITLE
feat: 自清洁提醒

### DIFF
--- a/sources_1/new/clean_reminder.v
+++ b/sources_1/new/clean_reminder.v
@@ -1,0 +1,57 @@
+`timescale 1ns / 1ps
+//  Module name: clean_reminder
+//  Description: This module is used to detect if working time is over threshold, only works in standby state
+//  Author: Kong Yifan
+//  Create Date: 2024/12/06
+
+module clean_reminder #(
+    //hour threshold
+    parameter [5:0] defalut_hour_threshold = 6'd10,
+    parameter [5:0] defalut_min_threshold = 6'd0,
+    parameter [5:0] defalut_sec_threshold = 6'd0
+) (
+    // Input ports
+    input            clk,
+    input is_standby,
+    input            rst_n,
+    input reg [5:0]      hour_threshold,
+    input reg [5:0]      min_threshold,
+    input reg [5:0]      sec_threshold,
+    input [5:0]      working_hour,
+    input [5:0]      working_min,
+    input [5:0]      working_sec,
+    // Output ports
+    // Warning signal, 1 means warning, 0 means no warning
+    output reg       warning
+);
+
+    // If no threshold is provided, use default values
+    assign hour_threshold = (hour_threshold == 0) ? defalut_hour_threshold : hour_threshold;
+    assign min_threshold = (min_threshold == 0) ? defalut_min_threshold : min_threshold;
+    assign sec_threshold = (sec_threshold == 0) ? defalut_sec_threshold : sec_threshold;
+
+    // Main logic
+    always @(posedge clk, negedge rst_n) begin
+        if (~rst_n) begin
+            warning <= 0;
+        end
+        else begin
+            // Check if at standby state (3'b001)
+            if (is_standby) begin
+                // Compare working time with threshold
+                if ((working_hour > hour_threshold) ||
+                    (working_hour == hour_threshold && working_min > min_threshold) ||
+                    (working_hour == hour_threshold && working_min == min_threshold && working_sec > sec_threshold)) begin
+                    warning <= 1;
+                end
+                else begin
+                    warning <= 0;
+                end
+            end
+            else begin
+                warning <= 0;
+            end
+        end
+    end
+
+endmodule

--- a/sources_1/new/clean_reminder_display.v
+++ b/sources_1/new/clean_reminder_display.v
@@ -1,0 +1,99 @@
+`timescale 1ns / 1ps
+//////////////////////////////////////////////////////////////////////////////////
+// Module Name: clean_reminder_display
+// Description: Display "CLEN" with blinking effect when cleaning is needed
+// Author: Kong Yifan
+// Create Date: 2024/12/07
+//////////////////////////////////////////////////////////////////////////////////
+
+module clean_reminder_display(
+    input clk_500Hz,          // 500Hz clock for display scanning
+    input rst_n,              // Active low reset
+    input warning,            // Warning signal from clean_reminder
+    output reg [3:0] seg_en,  // Segment enable signals
+    output reg [7:0] seg_out  // Segment output signals
+);
+
+    // Internal registers
+    reg [1:0] scan_cnt;       // Counter for display scanning
+    reg [3:0] display_data;   // Current digit to display
+    reg blink_state;          // Blinking state (on/off)
+    reg [8:0] blink_counter;  // Counter for blinking effect
+
+    // Character definitions for C, L, E, N
+    localparam C = 4'b1100;   // Display pattern for 'C'
+    localparam L = 4'b1101;   // Display pattern for 'L'
+    localparam E = 4'b1110;   // Display pattern for 'E'
+    localparam N = 4'b1111;   // Display pattern for 'N'
+
+    // Blinking effect counter
+    always @(posedge clk_500Hz or negedge rst_n) begin
+        if (~rst_n) begin
+            blink_counter <= 0;
+            blink_state <= 0;
+        end
+        else if (warning) begin
+            if (blink_counter == 9'd499) begin  // Toggle every 1 second (500Hz clock)
+                blink_counter <= 0;
+                blink_state <= ~blink_state;
+            end
+            else begin
+                blink_counter <= blink_counter + 1;
+            end
+        end
+        else begin
+            blink_state <= 1;  // Always on when no warning
+        end
+    end
+
+    // Display scanning counter
+    always @(posedge clk_500Hz or negedge rst_n) begin
+        if (~rst_n)
+            scan_cnt <= 0;
+        else
+            scan_cnt <= scan_cnt + 1;
+    end
+
+    // Segment enable control
+    always @(*) begin
+        if (~rst_n)
+            seg_en = 4'b1111;
+        else if (warning && blink_state)
+            case(scan_cnt)
+                2'b00: seg_en = 4'b1110;
+                2'b01: seg_en = 4'b1101;
+                2'b10: seg_en = 4'b1011;
+                2'b11: seg_en = 4'b0111;
+            endcase
+        else
+            seg_en = 4'b1111;  // All segments off during blink
+    end
+
+    // Display content control
+    always @(*) begin
+        case(scan_cnt)
+            2'b00: display_data = C;  // Display 'C'
+            2'b01: display_data = L;  // Display 'L'
+            2'b10: display_data = E;  // Display 'E'
+            2'b11: display_data = N;  // Display 'N'
+        endcase
+    end
+
+    // Seven-segment display decoder
+    always @(*) begin
+        if (~rst_n)
+            seg_out = 8'b1111_1111;
+        else if (warning && blink_state) begin
+            case(display_data)
+                C: seg_out = 8'b1100_0110;  // Pattern for 'C'
+                L: seg_out = 8'b1110_0111;  // Pattern for 'L'
+                E: seg_out = 8'b1000_0110;  // Pattern for 'E'
+                N: seg_out = 8'b1101_0101;  // Pattern for 'N'
+                default: seg_out = 8'b1111_1111;
+            endcase
+        end
+        else
+            seg_out = 8'b1111_1111;  // All segments off
+    end
+
+endmodule

--- a/sources_1/new/top_module.v
+++ b/sources_1/new/top_module.v
@@ -38,7 +38,7 @@ module top_module(
     output lighting_func,
     output [7:0] seg_en,
     output [7:0] seg_out1
-    //output [7:0] seg_out2,
+    output [7:0] seg_out2,
     );
     wire clk_100Hz, clk_500Hz;
     wire [2:0] state;
@@ -51,6 +51,7 @@ module top_module(
     wire [5:0] working_hour;
     wire [5:0] working_min;
     wire [5:0] working_sec;
+    wire clean_warning;
     wire [63:0] time_count_down_in_seconds;
     wire [5:0] count_down_sec;
     wire [5:0] count_down_min;
@@ -165,5 +166,25 @@ module top_module(
         .seg_en(seg_en[7:4]),
         .seg_out(seg_out1)
         );
+    clean_reminder clean_reminder_inst (
+        .clk(clk_100Hz),
+        .is_standby(is_standby),
+        .rst_n(rst_n),
+        // need to be set
+        .hour_threshold(6'd0), 
+        .min_threshold(6'd0),
+        .sec_threshold(6'd0),
+        .working_hour(working_hour),
+        .working_min(working_min),
+        .working_sec(working_sec),
+        .warning(clean_warning)
+    );
     
+    clean_reminder_display clean_reminder_display_inst (
+        .clk_500Hz(clk_500Hz),
+        .rst_n(rst_n),
+        .warning(clean_warning),
+        .seg_en(seg_en[3:0]),
+        .seg_out(seg_out2)
+    );
 endmodule


### PR DESCRIPTION
# 新功能
在待机状态下会触发自清洁提醒
## 注意事项
1. clean_reminder需要传入**设置后**的自清洁提醒阈值，目前使用默认阈值（10小时），如需测试，请更改为更小的值。
2. 此模块**不**负责自清洁后，累计工作时长的清零。
3. 请在测试时修改约束文件，为seg_out2等绑定引脚以启用数码显示管